### PR TITLE
ignore parser error

### DIFF
--- a/ppt.js
+++ b/ppt.js
@@ -7,7 +7,7 @@ if(typeof require !== 'undefined') {
 	if(typeof CFB === 'undefined') CFB = require('cf'+'b');
 	if(typeof cptable === 'undefined') cptable = require('code'+'page');
 }
-var parsenoop = function(blob, length) { throw new Error("n"); };
+var parsenoop = function(blob, length) { /*throw new Error("n");*/ };
 var parsenoop2 = function(blob, length) { blob.l += length; };
 
 /* helper to read arrays of records */


### PR DESCRIPTION
js-ppt fails to parse .ppt files that contain unsupported record types. We should ignore those records and allow the parsing to finish.